### PR TITLE
Feature/update documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,10 +28,15 @@ It _may_ work with other versions of Teamcity (unless there are breaking API cha
 
 When building the plugin, you need to have downloaded the Teamcity distribution you want to build against, so that the compilation process can grab the necessary libs. It's also useful so that you can test that it will load the plugin correctly.
 
-When running Teamcity locally, any plugins need to be installed by putting them in the TEAMCITY_DATA_PATH/plugins  folder. On Nix and OSX this defaults to */home/<user>/.BuildServer*.
+When running Teamcity locally, any plugins need to be installed by putting them in the TEAMCITY_DATA_PATH/plugins  folder.
+
+You can find the  TEAMCITY_DATA_PATH is set under  Administration > Server Configuration > GlobalSetting ( according to this documentation: http://confluence.jetbrains.com/display/TCD4/TeamCity+Data+Directory )
+
+On Nix and OSX this defaults to */home/<user>/.BuildServer*.
 
 On Windows is by default:%PROGRAMDATA%\JetBrains\TeamCity ( Windows 8, Teamcity Version 8.0.4 )
-You can find the  TEAMCITY_DATA_PATH is set under  Administration > Server Configuration > GlobalSetting ( according to this documentation: http://confluence.jetbrains.com/display/TCD4/TeamCity+Data+Directory )
+
+
 
 Before compiling, it's important to update the build.properties file with the paths the Teamcity distribution and to the TEAMCITY_DATA_PATH folder. When the process is complete, ant should automatically copy the unityRunner.zip file to the Datapath folder.
 


### PR DESCRIPTION
I had some troubles installing the prebuild runner. Because on Windows 8 TC 8.0.4 there is no BuildSettings Folder. After I figured it out - I updatet the Doku to a more generic path, and a link to the TC Doku on how you find the Folder on your machine. Maybe this helps others to - so here is  the pull request. 
